### PR TITLE
[LOG4J2-3310] Macro refactor - scala 3

### DIFF
--- a/src/main/scala-3/org/apache/logging/log4j/scala/Logger.scala
+++ b/src/main/scala-3/org/apache/logging/log4j/scala/Logger.scala
@@ -294,11 +294,8 @@ class Logger private(val delegate: ExtendedLogger) extends AnyVal {
     * @param marker  the marker data specific to this log statement
     * @param message the message to be logged
     */
-  inline def apply(inline level: Level, inline marker: Marker, inline message: Message): Unit = {
-    if (delegate.isEnabled(level, marker)) {
-      delegate.log(level, marker, message)
-    }
-  }
+  inline def apply(inline level: Level, inline marker: Marker, inline message: Message): Unit =
+    ${LoggerMacro.logMarkerMsg('this, 'level, 'marker, 'message)}
 
   /**
     * Logs a string with the specific `Marker` at the given `Level`.
@@ -317,11 +314,8 @@ class Logger private(val delegate: ExtendedLogger) extends AnyVal {
     * @param marker  the marker data specific to this log statement
     * @param message the message to be logged
     */
-  inline def apply(inline level: Level, inline marker: Marker, inline message: AnyRef): Unit = {
-    if (delegate.isEnabled(level, marker)) {
-      delegate.log(level, marker, message)
-    }
-  }
+  inline def apply(inline level: Level, inline marker: Marker, inline message: AnyRef): Unit =
+    ${LoggerMacro.logMarkerObject('this, 'level, 'marker, 'message)}
 
   /**
     * Logs a `Message` with the specific `Marker` at the given `Level` including the stack trace
@@ -332,11 +326,8 @@ class Logger private(val delegate: ExtendedLogger) extends AnyVal {
     * @param message the message to be logged
     * @param cause   the cause
     */
-  inline def apply(inline level: Level, inline marker: Marker, inline message: Message, inline cause: Throwable): Unit = {
-    if (delegate.isEnabled(level, marker)) {
-      delegate.log(level, marker, message, cause)
-    }
-  }
+  inline def apply(inline level: Level, inline marker: Marker, inline message: Message, inline cause: Throwable): Unit =
+    ${LoggerMacro.logMarkerMsgThrowable('this, 'level, 'marker, 'message, 'cause)}
 
   /**
     * Logs a string with the specific `Marker` at the given `Level` including the stack trace
@@ -359,11 +350,8 @@ class Logger private(val delegate: ExtendedLogger) extends AnyVal {
     * @param message the message to be logged
     * @param cause   the cause
     */
-  inline def apply(inline level: Level, inline marker: Marker, inline message: AnyRef, inline cause: Throwable): Unit = {
-    if (delegate.isEnabled(level, marker)) {
-      delegate.log(level, marker, message, cause)
-    }
-  }
+  inline def apply(inline level: Level, inline marker: Marker, inline message: AnyRef, inline cause: Throwable): Unit =
+    ${LoggerMacro.logMarkerObjectThrowable('this, 'level, 'marker, 'message, 'cause)}
 
   /**
     * Logs a `Message` at the given `Level`.
@@ -371,11 +359,8 @@ class Logger private(val delegate: ExtendedLogger) extends AnyVal {
     * @param level   the logging level
     * @param message the message to be logged
     */
-  inline def apply(inline level: Level, inline message: Message): Unit = {
-    if (delegate.isEnabled(level)) {
-      delegate.log(level, message)
-    }
-  }
+  inline def apply(inline level: Level, inline message: Message): Unit =
+    ${LoggerMacro.logMsg('this, 'level, 'message)}
 
   /**
     * Logs a string at the given `Level`.
@@ -392,11 +377,8 @@ class Logger private(val delegate: ExtendedLogger) extends AnyVal {
     * @param level   the logging level
     * @param message the message to be logged
     */
-  inline def apply(inline level: Level, inline message: AnyRef): Unit = {
-    if (delegate.isEnabled(level)) {
-      delegate.log(level, message)
-    }
-  }
+  inline def apply(inline level: Level, inline message: AnyRef): Unit =
+    ${LoggerMacro.logObject('this, 'level, 'message)}
 
   /**
     * Logs a `Message` at the given `Level` including the stack trace of the given `Throwable`.
@@ -405,11 +387,8 @@ class Logger private(val delegate: ExtendedLogger) extends AnyVal {
     * @param message the message to be logged
     * @param cause   a `Throwable`
     */
-  inline def apply(inline level: Level, inline message: Message, inline cause: Throwable): Unit = {
-    if (delegate.isEnabled(level)) {
-      delegate.log(level, message, cause)
-    }
-  }
+  inline def apply(inline level: Level, inline message: Message, inline cause: Throwable): Unit =
+    ${LoggerMacro.logMsgThrowable('this, 'level, 'message, 'cause)}
 
   /**
     * Logs a string at the given `Level` including the stack trace of the given `Throwable`.
@@ -428,11 +407,8 @@ class Logger private(val delegate: ExtendedLogger) extends AnyVal {
     * @param message the message to be logged
     * @param cause   a `Throwable`
     */
-  inline def apply(inline level: Level, inline message: AnyRef, inline cause: Throwable): Unit = {
-    if (delegate.isEnabled(level)) {
-      delegate.log(level, message, cause)
-    }
-  }
+  inline def apply(inline level: Level, inline message: AnyRef, inline cause: Throwable): Unit =
+    ${LoggerMacro.logObjectThrowable('this, 'level, 'message, 'cause)}
 
 
   /**

--- a/src/main/scala-3/org/apache/logging/log4j/scala/LoggerMacro.scala
+++ b/src/main/scala-3/org/apache/logging/log4j/scala/LoggerMacro.scala
@@ -387,6 +387,24 @@ private object LoggerMacro {
     '{ if ($underlying.delegate.isEnabled(Level.FATAL, $marker)) $underlying.fatal($marker, $message, $throwable) }
   }
 
+  def logMsg(underlying: Expr[Logger], level: Expr[Level], message: Expr[Message])(using Quotes): Expr[Unit] = {
+    '{ if ($underlying.delegate.isEnabled($level)) $underlying.delegate.log($level, $message) }
+  }
+
+  def logMsgThrowable(underlying: Expr[Logger], level: Expr[Level], message: Expr[Message], throwable: Expr[Throwable])
+                     (using Quotes): Expr[Unit] = {
+    '{ if ($underlying.delegate.isEnabled($level)) $underlying.delegate.log($level, $message, $throwable) }
+  }
+
+  def logObject(underlying: Expr[Logger], level: Expr[Level], message: Expr[AnyRef])(using Quotes): Expr[Unit] = {
+    '{ if ($underlying.delegate.isEnabled($level)) $underlying.delegate.log($level, $message) }
+  }
+
+  def logObjectThrowable(underlying: Expr[Logger], level: Expr[Level], message: Expr[AnyRef],
+                         throwable: Expr[Throwable])(using Quotes): Expr[Unit] = {
+    '{ if ($underlying.delegate.isEnabled($level)) $underlying.delegate.log($level, $message, $throwable) }
+  }
+
   def logCseq(underlying: Expr[Logger], level: Expr[Level], message: Expr[CharSequence])(using Quotes): Expr[Unit] = {
     val (messageFormat, args) = deconstructInterpolatedMessage(message)
     logMessageArgs(underlying, level, messageFormat, Expr.ofSeq(args))
@@ -396,6 +414,26 @@ private object LoggerMacro {
                        throwable: Expr[Throwable])(using Quotes): Expr[Unit] = {
     val (messageFormat, args) = deconstructInterpolatedMessage(message)
     logMessageArgsThrowable(underlying, level, messageFormat, Expr.ofSeq(args), throwable)
+  }
+
+  def logMarkerMsg(underlying: Expr[Logger], level: Expr[Level], marker: Expr[Marker], message: Expr[Message])
+                  (using Quotes): Expr[Unit] = {
+    '{ if ($underlying.delegate.isEnabled($level, $marker)) $underlying.delegate.log($level, $marker, $message) }
+  }
+
+  def logMarkerMsgThrowable(underlying: Expr[Logger], level: Expr[Level], marker: Expr[Marker], message: Expr[Message], throwable: Expr[Throwable])
+                  (using Quotes): Expr[Unit] = {
+    '{ if ($underlying.delegate.isEnabled($level, $marker)) $underlying.delegate.log($level, $marker, $message, $throwable) }
+  }
+
+  def logMarkerObject(underlying: Expr[Logger], level: Expr[Level], marker: Expr[Marker], message: Expr[AnyRef])
+                     (using Quotes): Expr[Unit] = {
+    '{ if ($underlying.delegate.isEnabled($level, $marker)) $underlying.delegate.log($level, $marker, $message) }
+  }
+
+  def logMarkerObjectThrowable(underlying: Expr[Logger], level: Expr[Level], marker: Expr[Marker], message: Expr[AnyRef],
+                               throwable: Expr[Throwable])(using Quotes): Expr[Unit] = {
+    '{ if ($underlying.delegate.isEnabled($level, $marker)) $underlying.delegate.log($level, $marker, $message, $throwable) }
   }
 
   def logMarkerCseq(underlying: Expr[Logger], level: Expr[Level], marker: Expr[Marker], message: Expr[CharSequence])(using Quotes): Expr[Unit] = {


### PR DESCRIPTION
Update apply methods to use macros - to match what happens with scala 2 build.

Relates to https://issues.apache.org/jira/browse/LOG4J2-3310