### PR TITLE
LOG4J2-3524: Revert "Bump Scala 3.x version to 3.1.2. (#20)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.10.7, 2.11.12, 2.12.15, 2.13.8, 3.1.2]
+        scala: [2.10.7, 2.11.12, 2.12.15, 2.13.8, 3.0.2]
         java: ['8', '11', '17']
     runs-on: ${{ matrix.os }}
     steps:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
   val scala211 = "2.11.12"
   val scala212 = "2.12.15"
   val scala213 = "2.13.8"
-  val scala3 = "3.1.2"
+  val scala3 = "3.0.2"
 
   def scalaReflect(version: String) =
     if (version.startsWith("3")) None else Some("org.scala-lang" % "scala-reflect" % version)


### PR DESCRIPTION
Relates to https://issues.apache.org/jira/browse/LOG4J2-3524