### PR TITLE
Fix BND configuration

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,11 @@
 -Djava.awt.headless=true
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/log4j-api-scala_2.10/pom.xml
+++ b/log4j-api-scala_2.10/pom.xml
@@ -31,6 +31,9 @@
   <properties>
     <scala.version.group>2.10</scala.version.group>
     <scala.version>${scala.version.group}.7</scala.version>
+
+    <!-- Prevents usage of `release` parameter to Javac -->
+    <maven.compiler.release />
   </properties>
 
   <dependencies>
@@ -104,6 +107,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-toolchains-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <!-- No advanced configuration required for a single `package-info.java` -->
+        <configuration combine.self="override" />
       </plugin>
 
       <plugin>

--- a/log4j-api-scala_2.10/src/main/scala/org/apache/logging/log4j/scala/package-info.java
+++ b/log4j-api-scala_2.10/src/main/scala/org/apache/logging/log4j/scala/package-info.java
@@ -1,0 +1,1 @@
+../../../../../../../../../log4j-api-scala_3/src/main/scala/org/apache/logging/log4j/scala/package-info.java

--- a/log4j-api-scala_2.11/pom.xml
+++ b/log4j-api-scala_2.11/pom.xml
@@ -31,6 +31,9 @@
   <properties>
     <scala.version.group>2.11</scala.version.group>
     <scala.version>${scala.version.group}.12</scala.version>
+
+    <!-- Prevents usage of `release` parameter to Javac -->
+    <maven.compiler.release />
   </properties>
 
   <dependencies>
@@ -96,6 +99,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-toolchains-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <!-- No advanced configuration required for a single `package-info.java` -->
+        <configuration combine.self="override" />
       </plugin>
 
       <plugin>

--- a/log4j-api-scala_2.11/src/main/scala/org/apache/logging/log4j/scala/package-info.java
+++ b/log4j-api-scala_2.11/src/main/scala/org/apache/logging/log4j/scala/package-info.java
@@ -1,0 +1,1 @@
+../../../../../../../../../log4j-api-scala_3/src/main/scala/org/apache/logging/log4j/scala/package-info.java

--- a/log4j-api-scala_2.12/src/main/scala/org/apache/logging/log4j/scala/package-info.java
+++ b/log4j-api-scala_2.12/src/main/scala/org/apache/logging/log4j/scala/package-info.java
@@ -1,0 +1,1 @@
+../../../../../../../../../log4j-api-scala_3/src/main/scala/org/apache/logging/log4j/scala/package-info.java

--- a/log4j-api-scala_2.13/src/main/scala/org/apache/logging/log4j/scala/package-info.java
+++ b/log4j-api-scala_2.13/src/main/scala/org/apache/logging/log4j/scala/package-info.java
@@ -1,0 +1,1 @@
+../../../../../../../../../log4j-api-scala_3/src/main/scala/org/apache/logging/log4j/scala/package-info.java

--- a/log4j-api-scala_3/src/main/scala/org/apache/logging/log4j/scala/package-info.java
+++ b/log4j-api-scala_3/src/main/scala/org/apache/logging/log4j/scala/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+@Export
+package org.apache.logging.log4j.scala;
+
+import org.osgi.annotation.bundle.Export;

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,21 @@
     <maven.compiler.target>8</maven.compiler.target>
     <maven.compiler.release>8</maven.compiler.release>
 
+    <!--
+      ~ Common OSGi and JPMS configuration.
+      ~ Please don't overwrite in modules.
+      -->
+    <bnd-module-name>org.apache.logging.log4j.scala</bnd-module-name>
+    <bnd-extra-package-options>
+      <!-- Scala reflection is optional -->
+      scala.reflect.*;resolution:=optional
+    </bnd-extra-package-options>
+    <bnd-extra-module-options>
+      <!-- Fix module names -->
+      scala.library;substitute="scala-library",
+      scala.reflect;substitute="scala-reflect";transitive=false
+    </bnd-extra-module-options>
+
     <!-- disable `maven-site-plugin`-->
     <maven.site.skip>true</maven.site.skip>
     <maven.site.deploy.skip>true</maven.site.deploy.skip>
@@ -200,6 +215,28 @@
 
     </dependencies>
   </dependencyManagement>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>biz.aQute.bnd</groupId>
+      <artifactId>biz.aQute.bnd.annotation</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>osgi.annotation</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.annotation.bundle</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+  </dependencies>
 
   <build>
 


### PR DESCRIPTION
Adds automatically computed JPMS modules descriptors to the artifacts.

This is a draft until `logging-parent` version `10.1.1` is published.

```
Archive:  log4j-api-scala_2.10/target/log4j-api-scala_2.10-13.0.0-SNAPSHOT.jar
module org.apache.logging.log4j.scala@13.0.0.SNAPSHOT {
  requires java.base;
  requires transitive org.apache.logging.log4j;
  requires transitive scala.library;
  requires static scala.reflect;
  exports org.apache.logging.log4j.scala;
}
Archive:  log4j-api-scala_2.11/target/log4j-api-scala_2.11-13.0.0-SNAPSHOT.jar
module org.apache.logging.log4j.scala@13.0.0.SNAPSHOT {
  requires java.base;
  requires transitive org.apache.logging.log4j;
  requires transitive scala.library;
  exports org.apache.logging.log4j.scala;
}
Archive:  log4j-api-scala_2.12/target/log4j-api-scala_2.12-13.0.0-SNAPSHOT.jar
module org.apache.logging.log4j.scala@13.0.0.SNAPSHOT {
  requires java.base;
  requires transitive org.apache.logging.log4j;
  requires transitive scala.library;
  requires static scala.reflect;
  exports org.apache.logging.log4j.scala;
}
Archive:  log4j-api-scala_2.13/target/log4j-api-scala_2.13-13.0.0-SNAPSHOT.jar
module org.apache.logging.log4j.scala@13.0.0.SNAPSHOT {
  requires java.base;
  requires transitive org.apache.logging.log4j;
  requires transitive scala.library;
  requires static scala.reflect;
  exports org.apache.logging.log4j.scala;
}
Archive:  log4j-api-scala_3/target/log4j-api-scala_3-13.0.0-SNAPSHOT.jar
module org.apache.logging.log4j.scala@13.0.0.SNAPSHOT {
  requires java.base;
  requires transitive org.apache.logging.log4j;
  requires transitive org.scala.lang.scala3.library;
  requires transitive scala.library;
  exports org.apache.logging.log4j.scala;
}
```