### PR TITLE
Add tests for Scala 3 macros

### DIFF
--- a/log4j-api-scala_3/src/main/scala/org/apache/logging/log4j/scala/LoggerMacro.scala
+++ b/log4j-api-scala_3/src/main/scala/org/apache/logging/log4j/scala/LoggerMacro.scala
@@ -496,7 +496,7 @@ private object LoggerMacro {
   }
 
   /** Checks whether `message` is an interpolated string and transforms it into LOG4J string interpolation. */
-  private def deconstructInterpolatedMessage(message: Expr[CharSequence])(using Quotes): (Expr[CharSequence], Seq[Expr[Any]]) = {
+  private[scala] def deconstructInterpolatedMessage(message: Expr[CharSequence])(using Quotes): (Expr[CharSequence], Seq[Expr[Any]]) = {
     import quotes.reflect.*
     import util.*
 
@@ -530,8 +530,8 @@ private object LoggerMacro {
       case _ => (message, Seq.empty)
     }
   }
-  
-  private def formatArgs(args: Expr[Seq[Any]])(using q: Quotes): Seq[Expr[Object]] = {
+
+  private[scala] def formatArgs(args: Expr[Seq[Any]])(using q: Quotes): Seq[Expr[Object]] = {
     import quotes.reflect.*
     import util.*
 

--- a/log4j-api-scala_3/src/test/scala/org/apache/logging/log4j/scala/LoggerTestMacros.scala
+++ b/log4j-api-scala_3/src/test/scala/org/apache/logging/log4j/scala/LoggerTestMacros.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.scala
+
+import scala.quoted.*
+
+object MacroBridge:
+  def deconstructMessageFormat(cs: Expr[CharSequence])(using Quotes): Expr[CharSequence] =
+    val (messageFormat, args) = LoggerMacro.deconstructInterpolatedMessage(cs)
+    messageFormat
+
+  def deconstructArgs(cs: Expr[CharSequence])(using Quotes): Expr[Seq[Any]] =
+    val (messageFormat, args) = LoggerMacro.deconstructInterpolatedMessage(cs)
+    Expr.ofSeq(args)
+
+object LoggerTestMacros:
+
+  inline def deconstructMessageFormat(inline cs: CharSequence): CharSequence =
+    ${ MacroBridge.deconstructMessageFormat('cs) }
+
+  inline def deconstructArgs(inline cs: CharSequence): Seq[Any] =
+    ${ MacroBridge.deconstructArgs('cs) }

--- a/log4j-api-scala_3/src/test/scala/org/apache/logging/log4j/scala/LoggerTestScala3.scala
+++ b/log4j-api-scala_3/src/test/scala/org/apache/logging/log4j/scala/LoggerTestScala3.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.scala
+
+import scala.collection.immutable.ArraySeq
+
+import org.junit.runner.RunWith
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+object LoggerTestScala3 extends AnyFunSuite with Matchers {
+  test("simple") {
+    val res = LoggerTestMacros.deconstructMessageFormat("foo")
+    res shouldEqual "foo"
+  }
+
+  test("interpolated") {
+    val emptyMap = Map.empty
+    val message = LoggerTestMacros.deconstructMessageFormat(s"interpolated $emptyMap")
+    message shouldEqual "interpolated {}"
+
+    val args = LoggerTestMacros.deconstructArgs(s"second $emptyMap")
+    args shouldEqual ArraySeq(emptyMap)
+  }
+}


### PR DESCRIPTION
This adds a few simple and short tests for the Scala 3 macros. Especially for the central deconstructMessageFormat() macro, which was previously broken and fixed with 66ac4a718112 ("Fixed Scala 3 macros (#26)").