### PR TITLE
Rework `traceEntry()` to avoid inlining warnings

### DIFF
--- a/log4j-api-scala_2.10/src/main/scala/org/apache/logging/log4j/scala/Logger.scala
+++ b/log4j-api-scala_2.10/src/main/scala/org/apache/logging/log4j/scala/Logger.scala
@@ -433,9 +433,10 @@ class Logger private(val delegate: ExtendedLogger) extends AnyVal {
     * @return The built `EntryMessage`
     */
   def traceEntry(params: AnyRef*): EntryMessage = {
-    params match {
-      case Seq() => delegate.traceEntry()
-      case seq => delegate.traceEntry(seq.head.toString, seq.tail:_*)
+    if (params.isEmpty) {
+      delegate.traceEntry()
+    } else {
+      delegate.traceEntry(params.head.toString, params.tail:_*)
     }
   }
 

--- a/log4j-api-scala_3/src/main/scala/org/apache/logging/log4j/scala/Logger.scala
+++ b/log4j-api-scala_3/src/main/scala/org/apache/logging/log4j/scala/Logger.scala
@@ -434,9 +434,10 @@ class Logger private(val delegate: ExtendedLogger) extends AnyVal {
     * @return The built `EntryMessage`
     */
   inline def traceEntry(inline params: AnyRef*): EntryMessage = {
-    params match {
-      case Seq() => delegate.traceEntry()
-      case seq => delegate.traceEntry(seq.head.toString, seq.tail:_*)
+    if (params.isEmpty) {
+      delegate.traceEntry()
+    } else {
+      delegate.traceEntry(params.head.toString, params.tail:_*)
     }
   }
 


### PR DESCRIPTION
@vy has reported seeing a compiler warning.

This impl should hopefully avoid that. In practice, the Scala compiler should be intelligent enough to direct all empty param calls to `traceEntry()` but it still regarded as good practice not to assume that a vararg list is non-empty.